### PR TITLE
fix: remove eslint error from test files

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,7 +4,20 @@ import peerDeps from 'rollup-plugin-peer-deps-external';
 
 import pkg from './package.json';
 
-const plugins = [typescript(), peerDeps(), bundleSize()];
+const plugins = [
+  typescript({
+    tsconfigOverride: {
+      exclude: [
+        'src/**/*.test.ts',
+        'src/**/*.test.tsx',
+        'src/**/*.spec.ts',
+        'src/**/*.spec.tsx',
+      ],
+    },
+  }),
+  peerDeps(),
+  bundleSize(),
+];
 
 const { name, source: input, main, browser, module: mjs } = pkg;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,5 @@
 {
   "compilerOptions": {
     "declaration": true
-  },
-  "exclude": [
-    "src/**/*.test.ts",
-    "src/**/*.test.tsx",
-    "src/**/*.spec.ts",
-    "src/**/*.spec.tsx"
-  ]
+  }
 }


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines
* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

ESLint shows parse error in test files, because it uses TypeScript parser, for which the config comes from `tsconfig.json` that ignores these files to not output empty `.d.ts` files in build output.

- **What is the new behavior (if this is a feature change)?**

Test files are only ignored while building. This was achieved by an override to the build config.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Nope.

- **Other information**:
